### PR TITLE
Add `modify-policy` action to an SQS Queue's IAM Policy

### DIFF
--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -256,6 +256,28 @@ class AddPolicyStatements(AddPolicyBase):
 
 @SQS.action_registry.register('modify-policy')
 class ModifyPolicyStatement(ModifyPolicyBase):
+    """Action to modify SQS Queue IAM policy statements.
+
+    :example:
+
+    .. code-block:: yaml
+
+           policies:
+              - name: sqs-yank-cross-account
+                resource: sws
+                filters:
+                  - type: cross-account
+                actions:
+                  - type: modify-policy
+                    add-statements: [{
+                        "Sid": "ReplaceWithMe",
+                        "Effect": "Allow",
+                        "Principal": "*",
+                        "Action": ["sqs:GetQueueAttributes"],
+                        "Resource": queue_url,
+                            }]
+                    remove-statements: '*'
+    """
     permissions = ('sqs:SetQueueAttributes', 'sqs:GetQueueAttributes')
 
     def process(self, resources):

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.CreateQueue_1.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.CreateQueue_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "QueueUrl": "https://queue.amazonaws.com/123456789123/test_sqs_modify_policy_add_remove_statements",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.DeleteQueue_1.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.DeleteQueue_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_1.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:c7n-mailer-test-queue",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1545055110",
+            "LastModifiedTimestamp": "1549869758",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_10.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_10.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:test",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1552487461",
+            "LastModifiedTimestamp": "1552500971",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_11.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_11.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:test_sqs_modify_policy_add_remove_statements",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1586195034",
+            "LastModifiedTimestamp": "1586195035",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"SpecificAllow\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789123:root\"},\"Action\":\"sqs:Subscribe\"},{\"Sid\":\"RemoveMe\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"sqs:GetqueueAttributes\"}]}",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_12.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_12.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:test-queue",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1532454087",
+            "LastModifiedTimestamp": "1532523498",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_13.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_13.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:vxe",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1548892066",
+            "LastModifiedTimestamp": "1548892066",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_14.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_14.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"SpecificAllow\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789123:root\"},\"Action\":\"sqs:Subscribe\"},{\"Sid\":\"AddMe\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"sqs:GetqueueAttributes\"}]}"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_2.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_2.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:c7nmailer-brenttestq",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1559780719",
+            "LastModifiedTimestamp": "1559780719",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_3.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_3.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:my-c7n-test",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1525459937",
+            "LastModifiedTimestamp": "1532454067",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_4.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_4.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:gh-event-archive",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1579988594",
+            "LastModifiedTimestamp": "1579988594",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_5.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_5.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:origin-dev",
+            "ApproximateNumberOfMessages": "5",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1546818761",
+            "LastModifiedTimestamp": "1546818761",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_6.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_6.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:origin-dev-test",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1546819890",
+            "LastModifiedTimestamp": "1546819890",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_7.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_7.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:origin-dev-test-2",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1546820436",
+            "LastModifiedTimestamp": "1546820436",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_8.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_8.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:origin-dev-test-3",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1546821784",
+            "LastModifiedTimestamp": "1546821784",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_9.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.GetQueueAttributes_9.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:resource-changes",
+            "ApproximateNumberOfMessages": "2127",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1539916425",
+            "LastModifiedTimestamp": "1539916497",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "1209600",
+            "DelaySeconds": "0",
+            "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"arn:aws:sqs:us-east-1:123456789123:resource-changes/SQSDefaultPolicy\",\"Statement\":[{\"Sid\":\"AWSEvents_resource-changes_Id319298710029\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"sqs:SendMessage\",\"Resource\":\"arn:aws:sqs:us-east-1:123456789123:resource-changes\",\"Condition\":{\"ArnEquals\":{\"aws:SourceArn\":\"arn:aws:events:us-east-1:123456789123:rule/resource-changes\"}}}]}",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.ListQueues_1.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.ListQueues_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200,
+    "data": {
+        "QueueUrls": [
+            "https://queue.amazonaws.com/123456789123/c7n-mailer-test-queue",
+            "https://queue.amazonaws.com/123456789123/c7nmailer-brenttestq",
+            "https://queue.amazonaws.com/123456789123/gh-event-archive",
+            "https://queue.amazonaws.com/123456789123/my-c7n-test",
+            "https://queue.amazonaws.com/123456789123/origin-dev",
+            "https://queue.amazonaws.com/123456789123/origin-dev-test",
+            "https://queue.amazonaws.com/123456789123/origin-dev-test-2",
+            "https://queue.amazonaws.com/123456789123/origin-dev-test-3",
+            "https://queue.amazonaws.com/123456789123/resource-changes",
+            "https://queue.amazonaws.com/123456789123/test",
+            "https://queue.amazonaws.com/123456789123/test-queue",
+            "https://queue.amazonaws.com/123456789123/test_sqs_modify_policy_add_remove_statements",
+            "https://queue.amazonaws.com/123456789123/vxe"
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.SetQueueAttributes_1.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.SetQueueAttributes_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.SetQueueAttributes_2.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/sqs.SetQueueAttributes_2.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_remove_statements/tagging.GetResources_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:sqs:us-east-1:123456789123:my-c7n-test",
+                "Tags": [
+                    {
+                        "Key": "OwnerContact",
+                        "Value": "ijm065"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:sqs:us-east-1:123456789123:test-queue",
+                "Tags": [
+                    {
+                        "Key": "ASV",
+                        "Value": "ASVTEST"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.CreateQueue_1.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.CreateQueue_1.json
@@ -1,0 +1,7 @@
+{
+    "status_code": 200,
+    "data": {
+        "QueueUrl": "https://queue.amazonaws.com/123456789123/test_sqs_modify_policy_add_statements",
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.DeleteQueue_1.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.DeleteQueue_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_1.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:c7n-mailer-test-queue",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1545055110",
+            "LastModifiedTimestamp": "1549869758",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_10.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_10.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:test",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1552487461",
+            "LastModifiedTimestamp": "1552500971",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_11.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_11.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:test-queue",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1532454087",
+            "LastModifiedTimestamp": "1532523498",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_12.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_12.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:test_sqs_modify_policy_add_statements",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1586197343",
+            "LastModifiedTimestamp": "1586197343",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"SpecificAllow\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789123:root\"},\"Action\":\"sqs:Subscribe\"}]}",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_13.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_13.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:vxe",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1548892066",
+            "LastModifiedTimestamp": "1548892066",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_14.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_14.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"SpecificAllow\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789123:root\"},\"Action\":\"sqs:Subscribe\"},{\"Sid\":\"AddMe\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"sqs:GetqueueAttributes\"}]}"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_2.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_2.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:c7nmailer-brenttestq",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1559780719",
+            "LastModifiedTimestamp": "1559780719",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_3.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_3.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:gh-event-archive",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1579988594",
+            "LastModifiedTimestamp": "1579988594",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_4.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_4.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:origin-dev",
+            "ApproximateNumberOfMessages": "5",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1546818761",
+            "LastModifiedTimestamp": "1546818761",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_5.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_5.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:my-c7n-test",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1525459937",
+            "LastModifiedTimestamp": "1532454067",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_6.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_6.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:origin-dev-test",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1546819890",
+            "LastModifiedTimestamp": "1546819890",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_7.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_7.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:origin-dev-test-3",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1546821784",
+            "LastModifiedTimestamp": "1546821784",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_8.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_8.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:origin-dev-test-2",
+            "ApproximateNumberOfMessages": "0",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1546820436",
+            "LastModifiedTimestamp": "1546820436",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "345600",
+            "DelaySeconds": "0",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_9.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.GetQueueAttributes_9.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:123456789123:resource-changes",
+            "ApproximateNumberOfMessages": "2127",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "CreatedTimestamp": "1539916425",
+            "LastModifiedTimestamp": "1539916497",
+            "VisibilityTimeout": "30",
+            "MaximumMessageSize": "262144",
+            "MessageRetentionPeriod": "1209600",
+            "DelaySeconds": "0",
+            "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"arn:aws:sqs:us-east-1:123456789123:resource-changes/SQSDefaultPolicy\",\"Statement\":[{\"Sid\":\"AWSEvents_resource-changes_Id319298710029\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"sqs:SendMessage\",\"Resource\":\"arn:aws:sqs:us-east-1:123456789123:resource-changes\",\"Condition\":{\"ArnEquals\":{\"aws:SourceArn\":\"arn:aws:events:us-east-1:123456789123:rule/resource-changes\"}}}]}",
+            "ReceiveMessageWaitTimeSeconds": "0"
+        },
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.ListQueues_1.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.ListQueues_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200,
+    "data": {
+        "QueueUrls": [
+            "https://queue.amazonaws.com/123456789123/c7n-mailer-test-queue",
+            "https://queue.amazonaws.com/123456789123/c7nmailer-brenttestq",
+            "https://queue.amazonaws.com/123456789123/gh-event-archive",
+            "https://queue.amazonaws.com/123456789123/my-c7n-test",
+            "https://queue.amazonaws.com/123456789123/origin-dev",
+            "https://queue.amazonaws.com/123456789123/origin-dev-test",
+            "https://queue.amazonaws.com/123456789123/origin-dev-test-2",
+            "https://queue.amazonaws.com/123456789123/origin-dev-test-3",
+            "https://queue.amazonaws.com/123456789123/resource-changes",
+            "https://queue.amazonaws.com/123456789123/test",
+            "https://queue.amazonaws.com/123456789123/test-queue",
+            "https://queue.amazonaws.com/123456789123/test_sqs_modify_policy_add_statements",
+            "https://queue.amazonaws.com/123456789123/vxe"
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.SetQueueAttributes_1.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.SetQueueAttributes_1.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.SetQueueAttributes_2.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/sqs.SetQueueAttributes_2.json
@@ -1,0 +1,6 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/data/placebo/test_sqs_modify_policy_add_statements/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_sqs_modify_policy_add_statements/tagging.GetResources_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:sqs:us-east-1:123456789123:my-c7n-test",
+                "Tags": [
+                    {
+                        "Key": "OwnerContact",
+                        "Value": "ijm065"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:sqs:us-east-1:123456789123:test-queue",
+                "Tags": [
+                    {
+                        "Key": "ASV",
+                        "Value": "ASVTEST"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {}
+    }
+}

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -383,6 +383,7 @@ class TestSqsAction(BaseTest):
                                 "Effect": "Allow",
                                 "Principal": "*",
                                 "Action": ["sqs:GetqueueAttributes"],
+                                "Resource": queue_url
                             }
                         ],
                         "remove-statements": [],
@@ -462,6 +463,7 @@ class TestSqsAction(BaseTest):
                                 "Effect": "Allow",
                                 "Principal": "*",
                                 "Action": ["sqs:GetqueueAttributes"],
+                                "Resource": queue_url
                             }
                         ],
                         "remove-statements": ["RemoveMe"],

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -334,6 +334,161 @@ class TestSqsAction(BaseTest):
         )
 
     @functional
+    def test_sqs_modify_policy_add_statements(self):
+        session_factory = self.replay_flight_data("test_sqs_modify_policy_add_statements")
+        client = session_factory().client("sqs")
+        name = "test_sqs_modify_policy_add_statements"
+        queue_url = client.create_queue(QueueName=name)["QueueUrl"]
+
+        def cleanup():
+            client.delete_queue(QueueUrl=queue_url)
+            if self.recording:
+                time.sleep(60)
+
+        self.addCleanup(cleanup)
+
+        client.set_queue_attributes(
+            QueueUrl=queue_url,
+            Attributes={
+                "Policy": json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Sid": "SpecificAllow",
+                                "Effect": "Allow",
+                                "Principal": {"AWS": "arn:aws:iam::644160558196:root"},
+                                "Action": ["sqs:Subscribe"],
+                            },
+                        ],
+                    }
+                ),
+            },
+        )
+
+        if self.recording:
+            time.sleep(30)
+
+        p = self.load_policy(
+            {
+                "name": "sqs-set-permissions-add-statements-policy",
+                "resource": "sqs",
+                "filters": [{"QueueUrl": queue_url}],
+                "actions": [
+                    {
+                        "type": "modify-policy",
+                        "add-statements": [
+                            {
+                                "Sid": "AddMe",
+                                "Effect": "Allow",
+                                "Principal": "*",
+                                "Action": ["sqs:GetqueueAttributes"],
+                            }
+                        ],
+                        "remove-statements": [],
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+
+        resources = p.run()
+        if self.recording:
+            time.sleep(30)
+
+        self.assertEqual(len(resources), 1)
+
+        data = json.loads(
+            client.get_queue_attributes(
+                QueueUrl=resources[0]["QueueUrl"], AttributeNames=["Policy"]
+            )["Attributes"]["Policy"]
+        )
+
+        self.assertTrue("AddMe" in [s["Sid"] for s in data.get("Statement", ())])
+
+    @functional
+    def test_sqs_modify_policy_add_remove_statements(self):
+        session_factory = self.replay_flight_data("test_sqs_modify_policy_add_remove_statements")
+        client = session_factory().client("sqs")
+        name = "test_sqs_modify_policy_add_remove_statements"
+        queue_url = client.create_queue(QueueName=name)["QueueUrl"]
+
+        def cleanup():
+            client.delete_queue(QueueUrl=queue_url)
+            if self.recording:
+                time.sleep(60)
+
+        self.addCleanup(cleanup)
+
+        client.set_queue_attributes(
+            QueueUrl=queue_url,
+            Attributes={
+                "Policy": json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Sid": "SpecificAllow",
+                                "Effect": "Allow",
+                                "Principal": {"AWS": "arn:aws:iam::644160558196:root"},
+                                "Action": ["sqs:Subscribe"],
+                            },
+                            {
+                                "Sid": "RemoveMe",
+                                "Effect": "Allow",
+                                "Principal": "*",
+                                "Action": ["sqs:GetqueueAttributes"],
+                            }
+                        ],
+                    }
+                ),
+            },
+        )
+
+        if self.recording:
+            time.sleep(30)
+
+        p = self.load_policy(
+            {
+                "name": "sqs_modify_policy_add_remove_statements",
+                "resource": "sqs",
+                "filters": [{"QueueUrl": queue_url}],
+                "actions": [
+                    {
+                        "type": "modify-policy",
+                        "add-statements": [
+                            {
+                                "Sid": "AddMe",
+                                "Effect": "Allow",
+                                "Principal": "*",
+                                "Action": ["sqs:GetqueueAttributes"],
+                            }
+                        ],
+                        "remove-statements": ["RemoveMe"],
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+
+        resources = p.run()
+        if self.recording:
+            time.sleep(30)
+
+        self.assertEqual(len(resources), 1)
+
+        data = json.loads(
+            client.get_queue_attributes(
+                QueueUrl=resources[0]["QueueUrl"], AttributeNames=["Policy"]
+            )["Attributes"]["Policy"]
+        )
+
+        statement_ids = {s["Sid"] for s in data.get("Statement", ())}
+        self.assertTrue("AddMe" in statement_ids)
+        self.assertTrue("RemoveMe" not in statement_ids)
+        self.assertTrue("SpecificAllow" in statement_ids)
+
+    @functional
     def test_sqs_mark_for_op(self):
         session_factory = self.replay_flight_data("test_sqs_mark_for_op")
         client = session_factory().client("sqs")


### PR DESCRIPTION
This PR adds a ModifyPolicyStatement class in sqs.py that is based off of the similar SNS implementation in sns.py. This enables users to use the `modify-policy` action to add and remove permission statements to an SQS Queue's IAM policy.

I added two tests, test_sqs_modify_policy_add_statements and test_sqs_modify_policy_add_remove_statements, found in tests/tests_sqs.py, and the corresponding placebo data that is generated from running these tests.